### PR TITLE
177571211 embed happening now events in event page

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -147,16 +147,4 @@ class ConferencesController < ApplicationController
   def current_user_has_unpaid_tickets?
     current_user && current_user_tickets.unpaid.any?
   end
-
-  def load_happening_now
-    events_schedules_list = get_happening_now_events_schedules(@conference)
-    @is_happening_next = false
-    if events_schedules_list.empty?
-      events_schedules_list = get_happening_next_events_schedules(@conference)
-      @is_happening_next = true
-    end
-    @events_schedules_limit = EVENTS_PER_PAGE
-    @events_schedules_length = events_schedules_list.length
-    @pagy, @events_schedules = pagy_array(events_schedules_list, items: @events_schedules_limit, link_extra: 'data-remote="true"')
-  end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -183,16 +183,4 @@ class ProposalsController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :password, :password_confirmation, :username)
   end
-
-  def load_happening_now
-    events_schedules_list = get_happening_now_events_schedules(@conference)
-    @is_happening_next = false
-    if events_schedules_list.empty?
-      events_schedules_list = get_happening_next_events_schedules(@conference)
-      @is_happening_next = true
-    end
-    @events_schedules_limit = EVENTS_PER_PAGE
-    @events_schedules_length = events_schedules_list.length
-    @pagy, @events_schedules = pagy_array(events_schedules_list, items: @events_schedules_limit, link_extra: 'data-remote="true"')
-  end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -170,8 +170,6 @@ class ProposalsController < ApplicationController
 
   def registrations; end
 
-  
-
   private
 
   def event_params

--- a/app/helpers/conference_helper.rb
+++ b/app/helpers/conference_helper.rb
@@ -98,6 +98,18 @@ module ConferenceHelper
     events_schedules
   end
 
+  def load_happening_now
+    events_schedules_list = get_happening_now_events_schedules(@conference)
+    @is_happening_next = false
+    if events_schedules_list.empty?
+      events_schedules_list = get_happening_next_events_schedules(@conference)
+      @is_happening_next = true
+    end
+    @events_schedules_limit = EVENTS_PER_PAGE
+    @events_schedules_length = events_schedules_list.length
+    @pagy, @events_schedules = pagy_array(events_schedules_list, items: @events_schedules_limit, link_extra: 'data-remote="true"')
+  end
+
   private
 
   def filter_events_schedules(conference, filter)

--- a/app/views/conferences/_about_and_happening_now.haml
+++ b/app/views/conferences/_about_and_happening_now.haml
@@ -18,7 +18,7 @@
       -# happening now events are displayed second in md or lg view
       - if conference.splashpage.include_happening_now? && conference.splashpage.include_program?
         - if conference.description.present?
-          .col-md-6.col-md-push-6.col-lg-4.col-lg-push-8{ style: 'margin-top: 60px'}
+          .col-md-6.col-md-push-6.col-lg-4.col-lg-push-8{ style: 'margin-top: 60px' }
             = yield :happening_now
         - else
           .col-md-12

--- a/app/views/conferences/_about_and_happening_now.haml
+++ b/app/views/conferences/_about_and_happening_now.haml
@@ -16,7 +16,7 @@
   .container
     .row
       -# happening now events are displayed second in md or lg view
-      - if conference.splashpage.include_happening_now && conference.splashpage.include_program
+      - if conference.splashpage.include_happening_now? && conference.splashpage.include_program?
         - if conference.description.present?
           .col-md-6.col-md-push-6.col-lg-4.col-lg-push-8
             = yield :happening_now

--- a/app/views/conferences/_about_and_happening_now.haml
+++ b/app/views/conferences/_about_and_happening_now.haml
@@ -18,7 +18,7 @@
       -# happening now events are displayed second in md or lg view
       - if conference.splashpage.include_happening_now? && conference.splashpage.include_program?
         - if conference.description.present?
-          .col-md-6.col-md-push-6.col-lg-4.col-lg-push-8
+          .col-md-6.col-md-push-6.col-lg-4.col-lg-push-8{ style: 'margin-top: 60px'}
             = yield :happening_now
         - else
           .col-md-12

--- a/app/views/conferences/_happening_now.haml
+++ b/app/views/conferences/_happening_now.haml
@@ -1,10 +1,10 @@
 - if events_schedules.present? && events_schedules.any?
   .row
-    %h2.text-center{ style: 'margin-bottom:30px' }
+    %h3.text-left{ style: 'margin-bottom:30px; padding-left:20px' }
       - if is_happening_next
-        Happening Next
+        Events Happening Next
       - else
-        Happening Now
+        Events Happening Now
   - events_schedules.each do |event_schedule|
     = render 'schedules/event', conference: conference, event_schedule: event_schedule, event: event_schedule.event, is_brief: true
   - if events_schedules_length > events_schedules_limit

--- a/app/views/conferences/_happening_now.haml
+++ b/app/views/conferences/_happening_now.haml
@@ -1,16 +1,15 @@
-- if conference.splashpage.include_program && conference.splashpage.include_happening_now
-  - if events_schedules.any?
-    .row
-      %h2.text-center{ style: 'margin-bottom:30px' }
-        - if is_happening_next
-          Happening Next
-        - else
-          Happening Now
-    - events_schedules.each do |event_schedule|
-      = render 'schedules/event', conference: conference, event_schedule: event_schedule, event: event_schedule.event, is_brief: true
-    - if events_schedules_length > events_schedules_limit
-      .container{ style: 'width:100%; text-align:center' }
-        != pagy_bootstrap_nav_js(pagy)
-  - else
-    .row
-      %h3.text-center There are no events scheduled yet.
+- if events_schedules.any?
+  .row
+    %h2.text-center{ style: 'margin-bottom:30px' }
+      - if is_happening_next
+        Happening Next
+      - else
+        Happening Now
+  - events_schedules.each do |event_schedule|
+    = render 'schedules/event', conference: conference, event_schedule: event_schedule, event: event_schedule.event, is_brief: true
+  - if events_schedules_length > events_schedules_limit
+    .container{ style: 'width:100%; text-align:center' }
+      != pagy_bootstrap_nav_js(pagy)
+- else
+  .row
+    %h3.text-center There are no events scheduled yet.

--- a/app/views/conferences/_happening_now.haml
+++ b/app/views/conferences/_happening_now.haml
@@ -1,4 +1,4 @@
-- if events_schedules.any?
+- if events_schedules.present? && events_schedules.any?
   .row
     %h2.text-center{ style: 'margin-bottom:30px' }
       - if is_happening_next

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -51,7 +51,7 @@
         - @event.volunteers.each do |volunteer|
           = render 'volunteer_info', speaker: volunteer, show_bio: false
 
-    .col-md-9
+    .col-md-6
       .row
         .col-md-12
           .lead
@@ -138,3 +138,11 @@
           - if @surveys_after_event.any? && @event.ended?
             .page-header
             = render partial: 'surveys/list', locals: { surveys: @surveys_after_event, conference: @conference }
+    .col-md-3
+      #happening-now
+        = render 'conferences/happening_now', conference: @conference,
+          events_schedules: @events_schedules, pagy: @pagy,
+          events_schedules_length: @events_schedules_length,
+          events_schedules_limit: @events_schedules_limit,
+          is_happening_next: @is_happening_next
+

--- a/app/views/proposals/show.js.erb
+++ b/app/views/proposals/show.js.erb
@@ -1,4 +1,4 @@
-$('#happening-now').html("<%= j(render 'happening_now', conference: @conference,
+$('#happening-now').html("<%= j(render 'conferences/happening_now', conference: @conference,
                                 events_schedules: @events_schedules, pagy: @pagy,
                                 events_schedules_length: @events_schedules_length,
                                 events_schedules_limit: @events_schedules_limit,

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -212,4 +212,109 @@ feature Event do
       expect(page.find('#event_submission_text').value).to eq(event_type.submission_instructions)
     end
   end
+
+  context 'happening now or next section', feature: true, js: true do
+    let!(:conference1) { create(:full_conference, start_date: 1.day.ago, end_date: 7.days.from_now, start_hour: 0, end_hour: 24) }
+    let!(:program) { conference1.program }
+    let!(:selected_schedule) { create(:schedule, program: program) }
+    let!(:splashpage) { create(:full_splashpage, conference: conference1, public: true) }
+
+    let!(:scheduled_event1) do
+      program.update_attributes!(selected_schedule: selected_schedule)
+      create(:event, program: program, state: 'confirmed')
+    end
+    let!(:scheduled_event2) do
+      program.update_attributes!(selected_schedule: selected_schedule)
+      create(:event, program: program, state: 'confirmed')
+    end
+    let!(:scheduled_event3) do
+      program.update_attributes!(selected_schedule: selected_schedule)
+      create(:event, program: program, state: 'confirmed')
+    end
+    let!(:scheduled_event4) do
+      program.update_attributes!(selected_schedule: selected_schedule)
+      create(:event, program: program, state: 'confirmed')
+    end
+    let!(:current_time) { Time.now.in_time_zone(conference1.timezone) }
+
+    let!(:events_list) { [scheduled_event1, scheduled_event2, scheduled_event3, scheduled_event4] }
+
+    before :each do
+      sign_in participant
+    end
+
+    scenario 'No events happening now or next' do
+      events_list.each do |event|
+        visit conference_program_proposal_path(conference1.short_title, event.id)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).to have_content('There are no events scheduled yet.')
+      end
+    end
+
+    scenario 'shows all events happening next if nothing is happening now' do
+      event_schedule1 = create(:event_schedule, event: scheduled_event1, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule2 = create(:event_schedule, event: scheduled_event2, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+
+      events_list.each do |event|
+        visit conference_program_proposal_path(conference1.short_title, event.id)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).to have_content(event_schedule1.event.title)
+        expect(happening_now).to have_content(event_schedule2.event.title)
+        expect(happening_now).not_to have_content(scheduled_event3.title)
+        expect(happening_now).not_to have_content(scheduled_event4.title)
+      end
+    end
+
+    scenario 'only shows all events happening now if something is happening now and next' do
+      event_schedule1 = create(:event_schedule, event: scheduled_event1, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule2 = create(:event_schedule, event: scheduled_event2, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule3 = create(:event_schedule, event: scheduled_event3, schedule: selected_schedule, start_time: current_time.strftime('%a, %d %b %Y %H:%M:%S'))
+      events_list.each do |event|
+        visit conference_program_proposal_path(conference1.short_title, event.id)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).not_to have_content(event_schedule1.event.title)
+        expect(happening_now).not_to have_content(event_schedule2.event.title)
+        expect(happening_now).to have_content(event_schedule3.event.title)
+        expect(happening_now).not_to have_content(scheduled_event4.title)
+      end
+    end
+
+    scenario 'only shows events happening at the earliest time, not at a later time in the future' do
+      event_schedule1 = create(:event_schedule, event: scheduled_event1, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule2 = create(:event_schedule, event: scheduled_event2, schedule: selected_schedule, start_time: (current_time + 1.hour).strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule3 = create(:event_schedule, event: scheduled_event3, schedule: selected_schedule, start_time: (current_time + 2.hours).strftime('%a, %d %b %Y %H:%M:%S'))
+      events_list.each do |event|
+        visit conference_program_proposal_path(conference1.short_title, event.id)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).to have_content(event_schedule1.event.title)
+        expect(happening_now).to have_content(event_schedule2.event.title)
+        expect(happening_now).not_to have_content(event_schedule3.event.title)
+        expect(happening_now).not_to have_content(scheduled_event4.title)
+      end
+    end
+
+    scenario 'only shows 3 events happening now because of pagination' do
+      event_schedule1 = create(:event_schedule, event: scheduled_event1, schedule: selected_schedule, start_time: current_time.strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule2 = create(:event_schedule, event: scheduled_event2, schedule: selected_schedule, start_time: current_time.strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule3 = create(:event_schedule, event: scheduled_event3, schedule: selected_schedule, start_time: current_time.strftime('%a, %d %b %Y %H:%M:%S'))
+      event_schedule4 = create(:event_schedule, event: scheduled_event4, schedule: selected_schedule, start_time: current_time.strftime('%a, %d %b %Y %H:%M:%S'))
+
+      events_list.each do |event|
+        visit conference_program_proposal_path(conference1.short_title, event.id)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).to have_content(event_schedule1.event.title)
+        expect(happening_now).to have_content(event_schedule2.event.title)
+        expect(happening_now).to have_content(event_schedule3.event.title)
+
+        visit conference_program_proposal_path(conference1.short_title, event.id, page: 2)
+        happening_now = page.find('#happening-now')
+        expect(happening_now).not_to have_content(event_schedule3.event.title)
+        expect(happening_now).not_to have_content(event_schedule1.event.title)
+        expect(happening_now).not_to have_content(event_schedule2.event.title)
+
+        expect(happening_now).to have_content(event_schedule4.event.title)
+
+      end
+    end
+  end
 end


### PR DESCRIPTION
### **Proposed Changes**

The events page displays paginated happening now events or happening next events if there are no happening now events. Integration tests have been added for the same.

Contributors
@rajavi-mishra Rajavi Mishra
@kingdish Jimmy Xu
@madhekare Esha Madhekar

### **High Fidelity Screenshots**

**Screenshot 1**
Description: For a scheduled event, show events happening now on the events page

<img width="1156" alt="Screen Shot 2021-04-21 at 12 55 20 PM" src="https://user-images.githubusercontent.com/59727634/115657835-6c6d0e00-a2ec-11eb-80e6-12f1bf22a6ec.png">


**Screenshot 2**
Description: For an unscheduled event, show events happening now on the events page

<img width="1125" alt="Screen Shot 2021-04-21 at 9 58 37 PM" src="https://user-images.githubusercontent.com/59727634/115657992-be159880-a2ec-11eb-9f8d-4d3c660129e9.png">


**Screenshot 3** 
Description: For both scheduled and unscheduled events, show the events page with happening next events if there are no happening now events

<img width="1140" alt="Screen Shot 2021-04-21 at 10 05 16 PM" src="https://user-images.githubusercontent.com/59727634/115658453-aab6fd00-a2ed-11eb-97d2-1c7f2e2de648.png">



**Screenshot 4** 
Description: Pagination is used to display 3 events per page

<img width="1108" alt="Screen Shot 2021-04-21 at 10 07 29 PM" src="https://user-images.githubusercontent.com/59727634/115658627-f9649700-a2ed-11eb-970c-b81226ef1c9f.png">
