### PR TITLE
Fix Heroku deploys

### DIFF
--- a/lib/tasks/demo_data_for_development.rake
+++ b/lib/tasks/demo_data_for_development.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'webmock'
-
 namespace :data do
   desc 'Create demo data for our local development'
   include FactoryBot::Syntax::Methods

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -80,25 +80,6 @@ FactoryBot.define do
     last_sign_in_at { Date.today }
     is_disabled { false }
 
-    after(:build) do |user|
-      url_mailbluster = 'https://api.mailbluster.com/api/leads/'
-      response_body = "{
-        \"message\": \"Lead created\",
-        \"lead\": {
-          \"id\": 329395,
-          \"firstName\": \"#{user.name}\",
-          \"lastName\": \"\",
-          \"fullName\": \"#{user.name}\",
-          \"email\": \"#{user.email}\",
-          \"subscribed\": true,
-          \"tags\": [
-            #{ENV['OSEM_NAME'] || 'snapcon'}
-          ],
-        }
-      }"
-      WebMock.stub_request(:post, url_mailbluster)
-        .to_return(body: response_body, status: 200)
-    end
     # Called by every user creation
 
     after(:create) do |user|


### PR DESCRIPTION
During the development of Mailbluster integration, a WebMock stub on user creations within the user factory was introduced. This stub is unnecessary given that calls to the Mailbluster API now occur within delayed jobs.