### PR TITLE
176894823 cleanup page title on conference materials page

### DIFF
--- a/app/views/admin/commercials/index.html.haml
+++ b/app/views/admin/commercials/index.html.haml
@@ -1,7 +1,7 @@
 .row
   .col-md-12
     .page-header
-      %h1 Session Materials
+      %h1 #{@conference.title} Materials
       %p.text-muted
         Conference materials will be displayed on the events in the
         = link_to 'schedule,', conference_schedule_path(@conference.short_title)

--- a/spec/features/commercials_spec.rb
+++ b/spec/features/commercials_spec.rb
@@ -10,11 +10,18 @@ feature Commercial do
   let!(:participant) { create(:user) }
 
   context 'in admin area' do
-    scenario 'adds, updates, deletes of a conference', feature: true, js: true do
+    
+    before do
       sign_in organizer
-
       visit admin_conference_commercials_path(conference.short_title)
+    end
 
+    scenario 'contains the conference name in the title', feature: true, js: true do
+      header = conference.title + " Materials"
+      expect(page).to have_content(header)
+    end
+
+    scenario 'adds, updates, deletes of a conference', feature: true, js: true do
       # Create valid commercial
       fill_in 'commercial_url', with: 'https://www.youtube.com/watch?v=M9bq_alk-sw'
       click_button 'Save Materials'

--- a/spec/features/commercials_spec.rb
+++ b/spec/features/commercials_spec.rb
@@ -10,14 +10,14 @@ feature Commercial do
   let!(:participant) { create(:user) }
 
   context 'in admin area' do
-    
+
     before do
       sign_in organizer
       visit admin_conference_commercials_path(conference.short_title)
     end
 
     scenario 'contains the conference name in the title', feature: true, js: true do
-      header = conference.title + " Materials"
+      header = conference.title + ' Materials'
       expect(page).to have_content(header)
     end
 


### PR DESCRIPTION
### Proposed Changes

1. The materials/commercials page for a conference displays conference title instead of the word "Session"
2. A test has been added for the same

**Contributors**
@rajavi-mishra Rajavi Mishra

### High Fidelity Screenshots

**Screenshot 1**
Description: For a given conference's materials/commercials page, the header should be conference title + " Materials"
_Following conference's title is "conf1"_

<img width="1008" alt="Screen Shot 2021-04-24 at 10 38 17 PM" src="https://user-images.githubusercontent.com/59727634/115982162-c4ef1600-a54d-11eb-8c8c-782161d3304a.png">
